### PR TITLE
fix: delete related blocks/txs/fork/syncstate when handle reorged slots

### DIFF
--- a/packages/api/src/routers/indexer/handleReorgedSlots.ts
+++ b/packages/api/src/routers/indexer/handleReorgedSlots.ts
@@ -27,9 +27,12 @@ export const handleReorgedSlots = jwtAuthedProcedure
   .input(inputSchema)
   .output(outputSchema)
   .mutation(async ({ ctx: { prisma }, input: { reorgedSlots } }) => {
+    // 1. Query reorged blocks and their related data
     const reorgedBlocks = await prisma.block.findMany({
       select: {
         hash: true,
+        slot: true,
+        timestamp: true,
         transactions: {
           select: {
             hash: true,
@@ -43,6 +46,7 @@ export const handleReorgedSlots = jwtAuthedProcedure
       },
     });
 
+    // 2. Create transaction fork records
     const result = await prisma.transactionFork.upsertMany(
       reorgedBlocks.flatMap((b) =>
         b.transactions.map((tx) => ({
@@ -51,6 +55,157 @@ export const handleReorgedSlots = jwtAuthedProcedure
         }))
       )
     );
+
+    // 3. Delete reorged block related data to prepare for re-indexing
+    const operations = [];
+
+    // Delete transactionFork records first to avoid foreign key constraint
+    const reorgedTxHashes = reorgedBlocks.flatMap(b => 
+      b.transactions.map(tx => tx.hash)
+    );
+    
+    if (reorgedTxHashes.length > 0) {
+      operations.push(
+        prisma.transactionFork.deleteMany({
+          where: {
+            hash: {
+              in: reorgedTxHashes
+            }
+          }
+        })
+      );
+    }
+
+    // Delete blobsOnTransactions for reorged blocks
+    if (reorgedTxHashes.length > 0) {
+      operations.push(
+        prisma.blobsOnTransactions.deleteMany({
+          where: {
+            txHash: {
+              in: reorgedTxHashes
+            }
+          }
+        })
+      );
+    }
+
+    // Delete transactions for reorged blocks
+    const reorgedBlockHashes = reorgedBlocks.map(b => b.hash);
+    operations.push(
+      prisma.transaction.deleteMany({
+        where: {
+          blockHash: {
+            in: reorgedBlockHashes
+          }
+        }
+      })
+    );
+
+    // Delete blobDataStorageReference for reorged blocks
+    // Note: We need to query which blobs are only referenced by these reorged blocks
+    const reorgedBlobHashes = await prisma.blob.findMany({
+      where: {
+        transactions: {
+          some: {
+            transaction: {
+              blockHash: {
+                in: reorgedBlockHashes
+              }
+            }
+          }
+        }
+      },
+      include: {
+        transactions: {
+          include: {
+            transaction: {
+              select: { blockHash: true }
+            }
+          }
+        }
+      }
+    });
+
+    // Only delete blobs that are exclusively referenced by reorged blocks
+    const safeToDeleteBlobs = reorgedBlobHashes
+      .filter(blob => blob.transactions.every((btx: any) => 
+        reorgedBlockHashes.includes(btx.transaction.blockHash)
+      ))
+      .map(blob => blob.versionedHash);
+
+    if (safeToDeleteBlobs.length > 0) {
+      operations.push(
+        prisma.blobDataStorageReference.deleteMany({
+          where: {
+            blobHash: {
+              in: safeToDeleteBlobs
+            }
+          }
+        })
+      );
+
+      operations.push(
+        prisma.blob.deleteMany({
+          where: {
+            versionedHash: {
+              in: safeToDeleteBlobs
+            }
+          }
+        })
+      );
+    }
+
+    // Delete reorged blocks
+    operations.push(
+      prisma.block.deleteMany({
+        where: {
+          slot: {
+            in: reorgedSlots
+          }
+        }
+      })
+    );
+
+    // 4. Execute delete operations
+    await prisma.$transaction(operations);
+
+    // 5. Update blockchain sync state to reflect reorg
+    if (reorgedBlocks.length > 0) {
+      // Find the minimum slot that was reorged
+      const minReorgedSlot = Math.min(...reorgedSlots);
+      
+      // Get current sync state
+      const currentSyncState = await prisma.blockchainSyncState.findUnique({
+        where: { id: 1 }
+      });
+
+      if (currentSyncState) {
+        // Update sync state to rollback to before the reorg
+        const updateData: any = {};
+        
+        // If lastUpperSyncedSlot is greater than or equal to the minimum reorged slot,
+        // we need to rollback to the slot before the reorg
+        if (currentSyncState.lastUpperSyncedSlot !== null && 
+            currentSyncState.lastUpperSyncedSlot >= minReorgedSlot) {
+          updateData.lastUpperSyncedSlot = minReorgedSlot - 1;
+        }
+        
+        // If lastLowerSyncedSlot is greater than or equal to the minimum reorged slot,
+        // we need to rollback to the slot before the reorg
+        if (currentSyncState.lastLowerSyncedSlot !== null && 
+            currentSyncState.lastLowerSyncedSlot >= minReorgedSlot) {
+          updateData.lastLowerSyncedSlot = minReorgedSlot - 1;
+        }
+
+        // Only update if we have changes to make
+        if (Object.keys(updateData).length > 0) {
+          await prisma.blockchainSyncState.update({
+            where: { id: 1 },
+            data: updateData
+          });
+        }
+      }
+    }
 
     let totalUpdatedSlots: number;
 


### PR DESCRIPTION
- issue
when slots reorged
<img width="1208" height="295" alt="WeChatWorkScreenshot_93496134-bc10-4ff5-b532-27485bd18d96" src="https://github.com/user-attachments/assets/772ed83a-b015-4032-8483-12e156ed0dca" />

the dillscan db data not deleted, when insert again, the error occurs
<img width="1172" height="260" alt="WeChatWorkScreenshot_8a0bb67a-65c0-4bf7-8a88-fa0703e788fe" src="https://github.com/user-attachments/assets/8cbc6822-c3f5-476c-ba99-5ff4c4ab6167" />
